### PR TITLE
Add level tracking web app

### DIFF
--- a/levels.html
+++ b/levels.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Student Level Tracker</title>
+    <link rel="stylesheet" href="styles.css">
+    <style>
+        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: center; }
+        .current-level { background-color: #ffd966; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>Student Level Tracker</h1>
+    <div class="controls">
+        <label for="levelCount">Number of Levels:</label>
+        <input type="number" id="levelCount" min="1" value="3">
+        <button id="setLevels">Set Levels</button>
+    </div>
+    <div class="controls">
+        <label for="studentName">Student Name:</label>
+        <input type="text" id="studentName">
+        <button id="addStudent">Add Student</button>
+    </div>
+    <table id="progressTable"></table>
+</div>
+<script type="module" src="levels.js"></script>
+</body>
+</html>

--- a/levels.html
+++ b/levels.html
@@ -4,11 +4,6 @@
     <meta charset="UTF-8">
     <title>Student Level Tracker</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
-        table { width: 100%; border-collapse: collapse; margin-top: 20px; }
-        th, td { border: 1px solid #ccc; padding: 8px; text-align: center; }
-        .current-level { background-color: #ffd966; }
-    </style>
 </head>
 <body>
 <div class="container">
@@ -23,7 +18,7 @@
         <input type="text" id="studentName">
         <button id="addStudent">Add Student</button>
     </div>
-    <table id="progressTable"></table>
+    <table id="progressTable" class="progress-table"></table>
 </div>
 <script type="module" src="levels.js"></script>
 </body>

--- a/levels.js
+++ b/levels.js
@@ -7,18 +7,20 @@ const table = document.getElementById('progressTable');
 let levelCount = parseInt(levelInput.value, 10);
 const students = [];
 
-function buildHeader() {
+function renderTable() {
+  table.innerHTML = '';
   const header = document.createElement('tr');
-  header.innerHTML = `<th>Student</th>`;
+  header.innerHTML = '<th>Student</th>';
   for (let i = 1; i <= levelCount; i++) {
     const th = document.createElement('th');
     th.textContent = `Level ${i}`;
     header.appendChild(th);
   }
   header.innerHTML += '<th>Up Changes</th><th>Down Changes</th>';
-  table.innerHTML = '';
   table.appendChild(header);
+  students.forEach((s, i) => addRow(s, i));
 }
+
 
 function addRow(student, index) {
   const row = document.createElement('tr');
@@ -26,7 +28,7 @@ function addRow(student, index) {
   let cells = `<td>${student.name}</td>`;
   for (let i = 1; i <= levelCount; i++) {
     const cls = i === student.level ? 'current-level' : '';
-    cells += `<td class="lvl${i} ${cls}"></td>`;
+    cells += `<td class="level-cell lvl${i} ${cls}"></td>`;
   }
   cells += `<td class="up">${student.up}</td><td class="down">${student.down}</td>`;
   row.innerHTML = cells;
@@ -61,8 +63,7 @@ function refreshRow(index) {
 
 setLevelsBtn.addEventListener('click', () => {
   levelCount = parseInt(levelInput.value, 10) || 1;
-  buildHeader();
-  students.forEach((_, i) => refreshRow(i));
+  renderTable();
 });
 
 addStudentBtn.addEventListener('click', () => {
@@ -70,8 +71,8 @@ addStudentBtn.addEventListener('click', () => {
   if (!name) return;
   const student = { name, level: 1, up: 0, down: 0 };
   students.push(student);
-  addRow(student, students.length - 1);
+  renderTable();
   studentInput.value = '';
 });
 
-buildHeader();
+renderTable();

--- a/levels.js
+++ b/levels.js
@@ -1,0 +1,77 @@
+const levelInput = document.getElementById('levelCount');
+const setLevelsBtn = document.getElementById('setLevels');
+const addStudentBtn = document.getElementById('addStudent');
+const studentInput = document.getElementById('studentName');
+const table = document.getElementById('progressTable');
+
+let levelCount = parseInt(levelInput.value, 10);
+const students = [];
+
+function buildHeader() {
+  const header = document.createElement('tr');
+  header.innerHTML = `<th>Student</th>`;
+  for (let i = 1; i <= levelCount; i++) {
+    const th = document.createElement('th');
+    th.textContent = `Level ${i}`;
+    header.appendChild(th);
+  }
+  header.innerHTML += '<th>Up Changes</th><th>Down Changes</th>';
+  table.innerHTML = '';
+  table.appendChild(header);
+}
+
+function addRow(student, index) {
+  const row = document.createElement('tr');
+  row.setAttribute('data-index', index);
+  let cells = `<td>${student.name}</td>`;
+  for (let i = 1; i <= levelCount; i++) {
+    const cls = i === student.level ? 'current-level' : '';
+    cells += `<td class="lvl${i} ${cls}"></td>`;
+  }
+  cells += `<td class="up">${student.up}</td><td class="down">${student.down}</td>`;
+  row.innerHTML = cells;
+  row.addEventListener('click', (e) => {
+    if (e.target.tagName !== 'TD') return;
+    const cellIndex = Array.from(row.children).indexOf(e.target) - 1;
+    if (cellIndex >= 0 && cellIndex < levelCount) {
+      updateLevel(index, cellIndex + 1);
+    }
+  });
+  table.appendChild(row);
+}
+
+function updateLevel(index, newLevel) {
+  const s = students[index];
+  if (newLevel === s.level) return;
+  if (newLevel > s.level) s.up += newLevel - s.level;
+  if (newLevel < s.level) s.down += s.level - newLevel;
+  s.level = newLevel;
+  refreshRow(index);
+}
+
+function refreshRow(index) {
+  const row = table.querySelector(`tr[data-index="${index}"]`);
+  for (let i = 1; i <= levelCount; i++) {
+    const cell = row.querySelector(`.lvl${i}`);
+    cell.classList.toggle('current-level', i === students[index].level);
+  }
+  row.querySelector('.up').textContent = students[index].up;
+  row.querySelector('.down').textContent = students[index].down;
+}
+
+setLevelsBtn.addEventListener('click', () => {
+  levelCount = parseInt(levelInput.value, 10) || 1;
+  buildHeader();
+  students.forEach((_, i) => refreshRow(i));
+});
+
+addStudentBtn.addEventListener('click', () => {
+  const name = studentInput.value.trim();
+  if (!name) return;
+  const student = { name, level: 1, up: 0, down: 0 };
+  students.push(student);
+  addRow(student, students.length - 1);
+  studentInput.value = '';
+});
+
+buildHeader();

--- a/styles.css
+++ b/styles.css
@@ -85,10 +85,39 @@
         .debug-outline {
             outline: 2px dashed red;
         }
-        .webAppId {
-            text-align: center;
-            margin-top: 20px;
-            font-size: 18px;
-            font-weight: bold;
-            color: #333;
-        }
+.webAppId {
+    text-align: center;
+    margin-top: 20px;
+    font-size: 18px;
+    font-weight: bold;
+    color: #333;
+}
+
+/* Styles for the Student Level Tracker */
+.progress-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 20px;
+    font-size: 1.1em;
+    background-color: #fff;
+}
+.progress-table th {
+    background-color: #6fa8dc;
+    color: #fff;
+}
+.progress-table th,
+.progress-table td {
+    border: 1px solid #ccc;
+    padding: 8px;
+    text-align: center;
+}
+.progress-table tr:nth-child(even) {
+    background-color: #f2f9ff;
+}
+.progress-table tr:hover {
+    background-color: #d9ead3;
+}
+.level-cell.current-level {
+    background-color: #ffd966;
+    font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- create a simple page to track student progress across levels
- allow teachers to configure number of levels and add students
- highlight a student's current level and record level changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685c07b6b2708326bf024287e9cc4376